### PR TITLE
Resolve "CLI decorator makes command help unreachable"

### DIFF
--- a/test/test_wumpus_cli.py
+++ b/test/test_wumpus_cli.py
@@ -2,7 +2,7 @@ from mock import MagicMock, patch
 
 from wumpus.game.game import GameStatus
 from wumpus.game.game_options import GameOptions
-from wumpus.cli.wumpus_cli import WumpusCli
+from wumpus.cli.wumpus_cli import WumpusCli, game_action
 
 
 class TestWumpusCli(object):
@@ -111,3 +111,10 @@ class TestWumpusCli(object):
         self.cli.do_start_game('')
         self.cli.do_turn('')
         self.render.assert_called_once_with(self.cli.game)
+
+    def it_preserves_docstring_using_game_action_decorator(self):
+        @game_action
+        def dummy_do_action_function(self, line):
+            """doc string"""
+
+        assert dummy_do_action_function.__doc__ == 'doc string'


### PR DESCRIPTION
Closes #8, closes #5 and closes #6 

Manual test:
```console
(venv) jamoh@jamoh-pc:~/github/wumpus(8-game-action-cli-commands-help-are-unreachable)$ ./wumpus_game.py 
Welcome Hunter to Wumpus dungeon,
Kill the Wumpus, take the gold and escape! You can ignore him but that's for chickens
PS: Take care with the bottomless pits :)

You can move forward, turn clockwise and anticlockwise.
If you think you have in front of you the Wumpus, take your bow and fire your powerful arrow!

Type help or ? to list available commands

For a new game, type start_game

Wumpus-CLI$ help turn
Turn clockwise or anticlockwise, usage: turn [clockwise|anticlockwise]
Wumpus-CLI$ help fire_arrow
Fires an arrow until it reaches the Wumpus or a wall. Usage: fire_arrow
Wumpus-CLI$ help take_the_gold
Takes the gold if you are in the same position. Usage: take_the_gold
Wumpus-CLI$ 
```